### PR TITLE
Specify body_format of the uri module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     url: "{{ topbeat_elasticsearch_url }}/_template/topbeat"
     method: PUT
     body: "{{ lookup('file','/tmp/ansible_fetch/topbeat.template.json') }}"
+    body_format: json
     status_code: 200
   when: topbeat_output_elasticsearch == true and topbeat_index_template_check.status == 404
   notify:


### PR DESCRIPTION
Hi,

I got an error using your module at the follwing step:

```
TASK [elastic-logstash-kibana : Create elasticsearch index template for topbeat] ***
fatal: [*******]: FAILED! => {"changed": false, "content": "", "failed": true, "msg": "Status code was not [200]: 
An unknown error occurred: must be string or buffer, not dict", "redirected": false, "status": -1, "url": "http://localhost:9200/_template/topbeat"}
```

I faced the issue described here: https://github.com/ansible/ansible-modules-core/issues/265 which have been fixed by this feature addiction to the module `uri`: https://github.com/ansible/ansible-modules-core/pull/1011 

Adding the body_format parameter helped.
